### PR TITLE
refactor: pass environment map by pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ const zzdoc = @import("zzdoc");
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
-    var environ = try init.environ_map.clone(allocator);
-    defer environ.deinit();
+    const environ = init.environ_map;
 
     var src = try std.Io.Dir.cwd().openFile(io, "zzdoc.5.scd", .{});
     var src_buffer: [1024]u8 = undefined;

--- a/main.zig
+++ b/main.zig
@@ -4,8 +4,7 @@ const zzdoc = @import("zzdoc.zig");
 pub fn main(init: std.process.Init) !void {
     const gpa = init.gpa;
     const io = init.io;
-    var environ = try init.environ_map.clone(gpa);
-    defer environ.deinit();
+    const environ = init.environ_map;
 
     var stdin_buffer: [1024]u8 = undefined;
     var stdin_reader = std.Io.File.stdin().reader(io, &stdin_buffer);

--- a/zzdoc.zig
+++ b/zzdoc.zig
@@ -80,7 +80,7 @@ pub const ManpageStep = struct {
             var dst_writer = dst.writer(io, &dst_buffer);
             defer dst.close(io);
 
-            try generate(io, b.allocator, b.graph.environ_map, &dst_writer.interface, &src_reader.interface);
+            try generate(io, b.allocator, &b.graph.environ_map, &dst_writer.interface, &src_reader.interface);
         }
 
         if (self.generated_manpages == null) {
@@ -116,7 +116,7 @@ pub const ManpageStep = struct {
     }
 };
 
-pub fn generate(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Environ.Map, writer: *std.Io.Writer, reader: *std.Io.Reader) !void {
+pub fn generate(io: std.Io, allocator: std.mem.Allocator, environ: *const std.process.Environ.Map, writer: *std.Io.Writer, reader: *std.Io.Reader) !void {
     var parser = try Parser.init(io, allocator, writer, reader);
 
     if (environ.get("SOURCE_DATE_EPOCH")) |src_date|


### PR DESCRIPTION
Both Zig 0.16 release notes and projects like https://github.com/ziglibs/known-folders agree that the env map should generally be passed by ptr, in https://github.com/rockorager/zzdoc/pull/2 I overthought the solution a bit.